### PR TITLE
Pin python3 users to alpine:3.8

### DIFF
--- a/mqtt-lwm2m/Dockerfile
+++ b/mqtt-lwm2m/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.8
 
 RUN apk add --no-cache python3 py3-pip && \
     pip3 install gpsd-py3 paho-mqtt sseclient pyyaml

--- a/ota-runner/Dockerfile
+++ b/ota-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.8
 
 RUN apk --no-cache add openssl python3 py3-pip \
 	&& apk --no-cache add python3-dev openssl-dev libffi-dev musl-dev gcc \


### PR DESCRIPTION
Python3 is broken in Alpine 3.9 and I haven't been able to get any
upstream attention on the issue.

Signed-off-by: Andy Doan <andy@foundries.io>