### PR TITLE
Make httpd.sh executable in docker container

### DIFF
--- a/shellhttpd-mqtt/Dockerfile
+++ b/shellhttpd-mqtt/Dockerfile
@@ -5,4 +5,5 @@ RUN apk add --no-cache mosquitto-clients vim
 
 COPY httpd.sh /usr/local/bin/
 
+RUN chmod +x /usr/local/bin/httpd.sh
 CMD ["/usr/local/bin/httpd.sh"]


### PR DESCRIPTION
This container doesn't start running and gives a permission denied error as the httpd.sh file doesn't have any executable privilege. The issue can be fixed by giving it this privilege.